### PR TITLE
fix arguments of ncolx and ncov_sample

### DIFF
--- a/R/causalForest.R
+++ b/R/causalForest.R
@@ -176,7 +176,8 @@ propensityForest <- function(formula, data, treatment,
                              bucketMax = 100, cv.option="CT", cv.Honest=T, minsize = 2L, 
                              propensity=mean(treatment), control, split.alpha = 0.5, cv.alpha = 0.5,  
                              sample.size.total = floor(nrow(data) / 10), sample.size.train.frac = 1,
-                             mtry = ceiling(ncol(data)/3), nodesize = 1, num.trees=nrow(data),ncolx=ncolx,ncov_sample=ncov_sample) {
+                             mtry = ceiling(ncol(data)/3), nodesize = 1, num.trees=nrow(data),
+                             ncolx=all.vars(formula)-1, ncov_sample) {
   
   # do not implement subset option of causalTree, inherited from rpart
   # do not implement weights and costs yet


### PR DESCRIPTION
This PR is about an issue https://github.com/susanathey/causalTree/issues/32 .

Sometimes the arguments formant of `ncolx=ncolx`  and `ncov_sample=ncov_sample` cause an error like 
`#> Error in sample.int(ncolx): promise already under evaluation: recursive default argument reference or earlier problems?`

So I fixed some points.

cf. https://stackoverflow.com/questions/4357101/promise-already-under-evaluation-recursive-default-argument-reference-or-earlie